### PR TITLE
Fix stopping sound when turned off, check for isHandItem instead of SecondaryItem.

### DIFF
--- a/media/lua/client/RadioCom/ISTCBoomboxWindow.lua
+++ b/media/lua/client/RadioCom/ISTCBoomboxWindow.lua
@@ -103,7 +103,7 @@ function ISTCBoomboxWindow:update()
 
         if self.deviceType and self.device and self.character and self.deviceData then
             if self.deviceType=="InventoryItem" then -- incase of inventory item check if player has it in a hand
-                if self.character:isHandItem(self.device) or self.character:isAttachedItem(self.device) then
+                if self.character:isHandItem(self.device) then
                     return;
                 end
             elseif self.deviceType == "IsoObject" or self.deviceType == "VehiclePart" then -- incase of isoobject check distance.
@@ -115,7 +115,7 @@ function ISTCBoomboxWindow:update()
     end
 
     if (self.deviceData and self.deviceType=="InventoryItem")
-       and not (self.character:isHandItem(self.device) or self.character:isAttachedItem(self.device)) then
+       and not self.character:isHandItem(self.device) then
         -- conveniently turn off radio when unequiped to prevent accidental loss of power.
         -- print("TURN OFF")
         self.device:getModData().tcmusic.isPlaying = false;

--- a/media/lua/client/RadioCom/ISTCBoomboxWindow.lua
+++ b/media/lua/client/RadioCom/ISTCBoomboxWindow.lua
@@ -103,8 +103,7 @@ function ISTCBoomboxWindow:update()
 
         if self.deviceType and self.device and self.character and self.deviceData then
             if self.deviceType=="InventoryItem" then -- incase of inventory item check if player has it in a hand
-                if -- self.character:getPrimaryHandItem() == self.device or 
-                self.character:getSecondaryHandItem() == self.device then
+                if self.character:isHandItem(self.device) or self.character:isAttachedItem(self.device) then
                     return;
                 end
             elseif self.deviceType == "IsoObject" or self.deviceType == "VehiclePart" then -- incase of isoobject check distance.
@@ -115,9 +114,9 @@ function ISTCBoomboxWindow:update()
         end
     end
 
-    if self.deviceData and self.deviceType=="InventoryItem" and
-        ( -- self.character:getPrimaryHandItem() ~= self.device and 
-        self.character:getSecondaryHandItem() ~= self.device) then        -- conveniently turn off radio when unequiped to prevent accidental loss of power.
+    if (self.deviceData and self.deviceType=="InventoryItem")
+       and not (self.character:isHandItem(self.device) or self.character:isAttachedItem(self.device)) then
+        -- conveniently turn off radio when unequiped to prevent accidental loss of power.
         -- print("TURN OFF")
         self.device:getModData().tcmusic.isPlaying = false;
         self.deviceData:setIsTurnedOn(false);

--- a/media/lua/client/RadioCom/ISTCRadioWindow.lua
+++ b/media/lua/client/RadioCom/ISTCRadioWindow.lua
@@ -8,7 +8,7 @@ function ISRadioWindow.activate( _player, _item, bol)
     if _player == getPlayer() then
         if instanceof(_item, "Radio") then
             if TCMusic.ItemMusicPlayer[_item:getFullType()] then
-                if _player:isHandItem(_item) or _player:isAttachedItem(_item) then
+                if _player:isHandItem(_item) then
                     ISTCBoomboxWindow.activate( _player, _item );
                 end
             elseif TCMusic.WorldMusicPlayer[_item:getFullType()] then

--- a/media/lua/client/RadioCom/ISTCRadioWindow.lua
+++ b/media/lua/client/RadioCom/ISTCRadioWindow.lua
@@ -8,7 +8,7 @@ function ISRadioWindow.activate( _player, _item, bol)
     if _player == getPlayer() then
         if instanceof(_item, "Radio") then
             if TCMusic.ItemMusicPlayer[_item:getFullType()] then
-                if _player:getSecondaryHandItem() == _item then
+                if _player:isHandItem(_item) or _player:isAttachedItem(_item) then
                     ISTCBoomboxWindow.activate( _player, _item );
                 end
             elseif TCMusic.WorldMusicPlayer[_item:getFullType()] then

--- a/media/lua/client/TCTickCheckMusic.lua
+++ b/media/lua/client/TCTickCheckMusic.lua
@@ -259,7 +259,7 @@ function OnRenderTickClientCheckMusic ()
                                 -- если игрока с музыкой нет в локальной таблице
                                 if not musicData then
                                     -- проверяем, что проигрыватель всё еще в руках игрока, запускаем музыку, записываем в локальную таблицу
-                                    if (player:isHandItem(musicServerData["itemid"]) or player:isAttachedItem(musicServerData["itemid"]))
+                                    if player:isHandItem(musicServerData["itemid"])
                                        and (musicPlayer:getDeviceData() and musicPlayer:getDeviceData():getPower() > 0) then
                                         local id = player:getEmitter():playSoundImpl(musicServerData["musicName"], nil)
                                         -- print("MUSIC ID:")
@@ -277,7 +277,7 @@ function OnRenderTickClientCheckMusic ()
                                 else
                                     -- если игрок в локальной таблице и музыка продолжает играть, контролируем громкость
                                     if player:getEmitter():isPlaying(musicData["localmusicid"]) then
-                                      if (player:isHandItem(musicServerData["itemid"]) or player:isAttachedItem(musicServerData["itemid"]))
+                                      if player:isHandItem(musicServerData["itemid"])
                                          and (musicPlayer:getDeviceData() and musicPlayer:getDeviceData():getPower() > 0)
                                          and (musicPlayer:getDeviceData():getIsTurnedOn()) then
                                           local koef = 0.4  -- коэффициент отвечающий за наличие наушников


### PR DESCRIPTION
This PR fixes a bug when a boombox is turned off or unequipped but the music still plays.

It also changes SecondaryItem checks so the radio item can be held in both hands, or attached (if it is attachable).