### PR TITLE
Fix vehicle volume error

### DIFF
--- a/media/lua/client/RadioCom/ISTCBoomboxAction.lua
+++ b/media/lua/client/RadioCom/ISTCBoomboxAction.lua
@@ -110,6 +110,8 @@ function ISTCBoomboxAction:performSetVolume()
         self.deviceData:setDeviceVolume(self.secondaryItem)
         if self.device:getModData().tcmusic.deviceType == "InventoryItem" then
             self.character:getEmitter():setVolume(self.character:getModData().tcmusicid, self.deviceData:getDeviceVolume() * 0.4)
+        elseif self.device:getModData().tcmusic.deviceType == "VehiclePart" then
+            -- TCTickCheckMusic should catch this and update the volume
         else
             self.deviceData:getEmitter():setVolumeAll(self.deviceData:getDeviceVolume() * 0.4)
         end


### PR DESCRIPTION
When adjusting vehicle volume, an error occurs since `self.deviceData:getEmitter` returns nil.

I just threw it up to TCTickCheckMusic to catch the volume change and update accordingly, since the vehicle updates both the sound emitter and a 3d sound emitter.

I'm not sure how this is handled in multiplayer, but it should work the same.